### PR TITLE
Use env variables to set max players

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
 
     tty: true
     restart: unless-stopped
+    environment:
+      - MAX_PLAYERS=50
     stdin_open: true
     container_name: aniv-ds
     user: "1000:1000"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 NOW=$( date '+%F_%H-%M-%S' )
+if [ -z "$MAX_PLAYERS"]
+then
+    MAX_PLAYERS=50
+fi
 echo "[ANIV] Checking for updates..."
 ./aniv-ds.sh validate anonymous
 cd aniv-ds

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,5 +3,5 @@ NOW=$( date '+%F_%H-%M-%S' )
 echo "[ANIV] Checking for updates..."
 ./aniv-ds.sh validate anonymous
 cd aniv-ds
-./aniv_server.x86_64 -map aneurismiv -maxplayers 50 -timestamps 2>&1 | tee ./logs/server_$NOW.log 
+./aniv_server.x86_64 -map aneurismiv -maxplayers $MAX_PLAYERS -timestamps 2>&1 | tee ./logs/server_$NOW.log 
 # ./aniv_server.x86_64 -map nightmare -timestamps


### PR DESCRIPTION
missed opertunity here, you can set the max players via the docker-compose. So you dont require a rebuild to change player count

added a default 50 for the steam CMD fans

we run this on a community server(minus the default) and seems to work as expected. test yourself ofcourse to be sure.

@ me on discord `tisme.` if you got any questions